### PR TITLE
Change player color pallete so it's more visible and not white

### DIFF
--- a/server/config/game/colours.json
+++ b/server/config/game/colours.json
@@ -1,7 +1,7 @@
 [
     {
-        "alias": "Alien Black",
-        "value": "0x1A2228"
+        "alias": "Admiral",
+        "value": "0x051094"
     },
     {
         "alias": "Aqua",
@@ -12,6 +12,10 @@
         "value": "0x4B5320"
     },
     {
+        "alias": "Arsenal Red",
+        "value": "0xDB0007"
+    },
+    {
         "alias": "Artic",
         "value": "0x82EEFD"
     },
@@ -20,12 +24,12 @@
         "value": "0x0000FF"
     },
     {
-        "alias": "Brown",
-        "value": "0x964B00"
+        "alias": "Bronze",
+        "value": "0xB2560D"
     },
     {
-        "alias": "Canary",
-        "value": "0xffff00"
+        "alias": "Brown",
+        "value": "0x964B00"
     },
     {
         "alias": "Citrine",
@@ -36,8 +40,8 @@
         "value": "0xB87333"
     },
     {
-        "alias": "Cyan",
-        "value": "0xOOFFFF"
+        "alias": "Crimson",
+        "value": "0x004b49"
     },
     {
         "alias": "Dark Slate Gray",
@@ -60,24 +64,16 @@
         "value": "0x008000"
     },
     {
-        "alias": "Gold",
-        "value": "0xFFD700"
-    },
-    {
-        "alias": "Gunmetal",
-        "value": "0x2A3439"
-    },
-    {
-        "alias": "Honey",
-        "value": "0xEC9706"
-    },
-    {
         "alias": "Lime",
         "value": "0x00FF00"
     },
     {
         "alias": "Imperial Blue",
         "value": "0x005A92"
+    },
+    {
+        "alias": "Imperial Red",
+        "value": "0xED2939"
     },
     {
         "alias": "Maroon",
@@ -108,12 +104,24 @@
         "value": "0xFF0000"
     },
     {
+        "alias": "Rust",
+        "value": "0x8D4004"
+    },
+    {
         "alias": "Sand",
         "value": "0xD8B863"
     },
     {
         "alias": "Space Cadet",
         "value": "0x1D2951"
+    },
+    {
+        "alias": "Steel",
+        "value": "0x4682B4"
+    },
+    {
+        "alias": "Swamp",
+        "value": "0xA8C090"
     },
     {
         "alias": "Tan",
@@ -126,6 +134,10 @@
     {
         "alias": "Twitter Blue",
         "value": "0x26a7de"
+    },
+    {
+        "alias": "Ultra Violet",
+        "value": "0x645394"
     },
     {
         "alias": "Yellow",

--- a/server/config/game/colours.json
+++ b/server/config/game/colours.json
@@ -36,6 +36,10 @@
         "value": "0x808000"
     },
     {
+        "alias": "Orange",
+        "value": "0xFFA500"
+    },
+    {
         "alias": "Purple",
         "value": "0x800080"
     },

--- a/server/config/game/colours.json
+++ b/server/config/game/colours.json
@@ -8,6 +8,10 @@
         "value": "0x0000FF"
     },
     {
+        "alias": "Brown",
+        "value": "0x964B00"
+    },
+    {
         "alias": "Fuchsia",
         "value": "0xFF00FF"
     },

--- a/server/config/game/colours.json
+++ b/server/config/game/colours.json
@@ -1,7 +1,19 @@
 [
     {
+        "alias": "Alien Black",
+        "value": "0x1A2228"
+    },
+    {
         "alias": "Aqua",
         "value": "0x00FFFF"
+    },
+    {
+        "alias": "Army Green",
+        "value": "0x4B5320"
+    },
+    {
+        "alias": "Artic",
+        "value": "0x82EEFD"
     },
     {
         "alias": "Blue",
@@ -12,20 +24,60 @@
         "value": "0x964B00"
     },
     {
-        "alias": "Fuchsia",
-        "value": "0xFF00FF"
+        "alias": "Canary",
+        "value": "0xffff00"
     },
     {
-        "alias": "Gray",
-        "value": "0x808080"
+        "alias": "Citrine",
+        "value": "0xE4D00A"
+    },
+    {
+        "alias": "Copper",
+        "value": "0xB87333"
+    },
+    {
+        "alias": "Cyan",
+        "value": "0xOOFFFF"
+    },
+    {
+        "alias": "Dark Slate Gray",
+        "value": "0x2F4F4F"
+    },
+    {
+        "alias": "Deep Jungle Green",
+        "value": "0x004b49"
+    },
+    {
+        "alias": "Fire",
+        "value": "0xDD571C"
+    },
+    {
+        "alias": "Fuchsia",
+        "value": "0xFF00FF"
     },
     {
         "alias": "Green",
         "value": "0x008000"
     },
     {
+        "alias": "Gold",
+        "value": "0xFFD700"
+    },
+    {
+        "alias": "Gunmetal",
+        "value": "0x2A3439"
+    },
+    {
+        "alias": "Honey",
+        "value": "0xEC9706"
+    },
+    {
         "alias": "Lime",
         "value": "0x00FF00"
+    },
+    {
+        "alias": "Imperial Blue",
+        "value": "0x005A92"
     },
     {
         "alias": "Maroon",
@@ -44,22 +96,6 @@
         "value": "0xFFA500"
     },
     {
-        "alias": "Purple",
-        "value": "0x800080"
-    },
-    {
-        "alias": "Red",
-        "value": "0xFF0000"
-    },
-    {
-        "alias": "Teal",
-        "value": "0x008080"
-    },
-    {
-        "alias": "Yellow",
-        "value": "0xFFFF00"
-    },
-    {
         "alias": "Pink",
         "value": "0xffb6c1"
     },
@@ -68,7 +104,31 @@
         "value": "0x800080"
     },
     {
-        "alias": "Orange",
-        "value": "0xff7a2a"
+        "alias": "Red",
+        "value": "0xFF0000"
+    },
+    {
+        "alias": "Sand",
+        "value": "0xD8B863"
+    },
+    {
+        "alias": "Space Cadet",
+        "value": "0x1D2951"
+    },
+    {
+        "alias": "Tan",
+        "value": "0xD2B48C"
+    },
+    {
+        "alias": "Teal",
+        "value": "0x008080"
+    },
+    {
+        "alias": "Twitter Blue",
+        "value": "0x26a7de"
+    },
+    {
+        "alias": "Yellow",
+        "value": "0xFFFF00"
     }
 ]

--- a/server/config/game/colours.json
+++ b/server/config/game/colours.json
@@ -44,10 +44,6 @@
         "value": "0xFF0000"
     },
     {
-        "alias": "Silver",
-        "value": "0xe0e0e0"
-    },
-    {
         "alias": "Teal",
         "value": "0x008080"
     },
@@ -58,6 +54,10 @@
     {
         "alias": "Pink",
         "value": "0xffb6c1"
+    },
+    {
+        "alias": "Purple",
+        "value": "0x800080"
     },
     {
         "alias": "Orange",


### PR DESCRIPTION
Changes have been made so that white and colors close to white are removed. 

Other colors have been selected and tested to see how they work for visibility and so far I think this is closer to what we want. We may want to add more or remove some colors as we run into issues but this is a major improvement on the previous list of colors.